### PR TITLE
Ivorblockley dewpoint from rh

### DIFF
--- a/atmos/moisture.py
+++ b/atmos/moisture.py
@@ -17,7 +17,8 @@ from atmos.thermo import (mixing_ratio,
                           relative_humidity,
                           saturation_vapour_pressure,
                           saturation_specific_humidity,
-                          saturation_mixing_ratio, 
+                          saturation_mixing_ratio,
+                          dewpoint_temperature_from_relative_humidity,
                           dewpoint_temperature,
                           frost_point_temperature,
                           saturation_point_temperature,
@@ -532,26 +533,6 @@ def dewpoint_temperature_from_vapour_pressure(p, T, e):
 
     """
     q = specific_humidity_from_vapour_pressure(p, e)
-    Td = dewpoint_temperature(p, T, q)
-
-    return Td
-    
-    
-def dewpoint_temperature_from_relative_humidity(p, T, RH):
-    """
-    Computes dewpoint temperature from pressure, temperature, and relative
-    humidity with respect to liquid water.
-
-    Args:
-        p (float or ndarray): pressure (Pa)
-        T (float or ndarray): temperature (K)
-        RH (float or ndarray): relative humidity (fraction)
-
-    Returns:
-        Td (float or ndarray): dewpoint temperature (K)
-
-    """
-    q = specific_humidity_from_relative_humidity(p, T, RH, phase='liquid')
     Td = dewpoint_temperature(p, T, q)
 
     return Td


### PR DESCRIPTION
For your consideration - this is a minor refactor to change the function signature of `dewpoint_temperature_from_relative_humidity(p, T, RH)` to one without `p`. Clearly `p` is not needed for this calculation and this slightly simpler definition is the more natural inverse of `relative_humidity_from_dewpoint_temperature(T, Td)` which also doesn't take `p` as an argument.

Could of course perform a similar refactor for `frostpoint_temperature` taking `RH_ice` as an argument but I think the use-cases would be fewer.

Note: `mosture.py` imports this new function but doesn't use it. However I believe this serves to exposes this function via the `moisture` module as this may still be desirable.